### PR TITLE
fmt and fix bitflags

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -77,7 +77,7 @@ bitflags::bitflags! {
         /// Request overloads that use sampler2DMSArray
         const D2_MULTI_TEXTURES_ARRAY = 1 << 3;
         /// Request overloads that use combined image samplers
-        const COMBINED_IMAGE_SAMPLERS = 1 << 3;
+        const COMBINED_IMAGE_SAMPLERS = 1 << 4;
     }
 }
 

--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -187,7 +187,11 @@ pub fn inject_builtin(
 
                     let class = match shadow {
                         true => ImageClass::Depth { multi },
-                        false => ImageClass::Sampled { kind, multi, includes_sampler },
+                        false => ImageClass::Sampled {
+                            kind,
+                            multi,
+                            includes_sampler,
+                        },
                     };
 
                     let image = TypeInner::Image {
@@ -279,7 +283,11 @@ pub fn inject_builtin(
                 let class = match shadow {
                     true => ImageClass::Depth { multi },
                     // todo: check for combined image sampler
-                    false => ImageClass::Sampled { kind, multi, includes_sampler },
+                    false => ImageClass::Sampled {
+                        kind,
+                        multi,
+                        includes_sampler,
+                    },
                 };
 
                 let image = TypeInner::Image {
@@ -319,7 +327,11 @@ pub fn inject_builtin(
                     dim,
                     arrayed,
                     // todo: check for combined image sampler
-                    class: ImageClass::Sampled { kind, multi, includes_sampler },
+                    class: ImageClass::Sampled {
+                        kind,
+                        multi,
+                        includes_sampler,
+                    },
                 };
 
                 let dim_value = image_dims_to_coords_size(dim);
@@ -492,7 +504,7 @@ fn inject_standard_builtins(
                             kind: Sk::Float,
                             multi: matches!(name, "sampler2DMS" | "sampler2DMSArray"),
                             // todo: check for combined image sampler
-                            includes_sampler: false
+                            includes_sampler: false,
                         },
                     },
                     TypeInner::Sampler { comparison: false },
@@ -525,7 +537,7 @@ fn inject_standard_builtins(
                             kind: Sk::Float,
                             multi: false,
                             // todo: check for combined image sampler
-                            includes_sampler: false
+                            includes_sampler: false,
                         },
                         _ => ImageClass::Depth { multi: false },
                     },
@@ -1761,7 +1773,16 @@ impl MacroCall {
                         .map_or(SampleLevel::Auto, SampleLevel::Bias);
                 }
 
-                texture_call(parser, ctx, args[0], level, comps, texture_offset, body, meta)?
+                texture_call(
+                    parser,
+                    ctx,
+                    args[0],
+                    level,
+                    comps,
+                    texture_offset,
+                    body,
+                    meta,
+                )?
             }
 
             MacroCall::TextureSize { arrayed } => {
@@ -2135,8 +2156,14 @@ fn texture_call(
             meta,
             body,
         ))
-    } else if let TypeInner::Image { class: ImageClass::Sampled { includes_sampler: true, .. }, .. }
-        = ctx.typifier.get(image, &parser.module.types) {
+    } else if let TypeInner::Image {
+        class: ImageClass::Sampled {
+            includes_sampler: true,
+            ..
+        },
+        ..
+    } = ctx.typifier.get(image, &parser.module.types)
+    {
         let mut array_index = comps.array_index;
         if let Some(ref mut array_index_expr) = array_index {
             ctx.conversion(array_index_expr, meta, Sk::Sint, 4)?;
@@ -2362,7 +2389,7 @@ bitflags::bitflags! {
         /// Generates cube arrayed images
         const D2_MULTI_ARRAY = 1 << 4;
         /// Generates combined image samplers
-        const COMBINED_IMAGE_SAMPLERS = 1 << 4;
+        const COMBINED_IMAGE_SAMPLERS = 1 << 5;
     }
 }
 


### PR DESCRIPTION
Hello @chyyran !

Sorry for the delay, I just made a simple fix on the bitflags, and this works for me. Be sure to use `WriteFlags::empty()` when you do the conversion to avoid the `extension texture_lod` to be added to your final shader.

This works for me, although the name of the uniforms (blocks and textures) are changes and I am having some issues with my code to keep the compatibility when I do the bindings, but I guess that's related to how I use the output and not related to how naga do it, so I will try to "map" what I do to the output. 

Thanks for your work on this!